### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python main.py 0.03"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Pass values for epsilon in as arguments to the program.
 
 ## Examples
 
+[![Run on Repl.it](https://repl.it/badge/github/elunico/RDP-Algorithm)](https://repl.it/github/elunico/RDP-Algorithm)
+
 `python main.py 0.01`
 ![Screenshot of matplotlib showing the program run with 0.01 as argument](images/rdp-001.png)
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@elunico/RDP-Algorithm).